### PR TITLE
Restore last sketch feature - autosave and reopen last sketch

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -563,9 +563,31 @@ public class Base {
 
     // Create a new empty window (will be replaced with any files to be opened)
     if (!opened) {
-      Messages.log("Calling handleNew() to open a new window");
-      handleNew();
-    } else {
+      System.out.println("Preferences file location: " + Base.getSettingsFile("preferences.txt").getAbsolutePath());
+      String lastPath = Preferences.get("last.sketch.path");
+      Messages.log("DEBUG: last.sketch.path = " + lastPath);
+
+      if (lastPath != null) {
+        File sketchFolder = new File(lastPath);
+        if (sketchFolder.exists()) {
+          Messages.log("Restoring last sketch at: " + lastPath);
+          File mainSketchFile = Sketch.findMain(sketchFolder, getModeList());
+          if (mainSketchFile != null) {
+            handleOpen(mainSketchFile.getAbsolutePath());
+          } else {
+            Messages.log("Could not find main sketch file in folder, falling back to new sketch");
+            handleNew();
+          }
+        } else {
+          Messages.log("Last sketch path not found, falling back to new sketch");
+          handleNew();
+        }
+      } else {
+        Messages.log("No saved sketch path, opening new sketch");
+        handleNew();
+      }
+
+  } else {
       Messages.log("No handleNew(), something passed on the command line");
     }
 
@@ -1456,6 +1478,10 @@ public class Base {
     }
 
     File parentFolder = pdeFile.getParentFile();
+    Preferences.set("last.sketch.path", parentFolder.getAbsolutePath());
+    Preferences.save(); // force write to disk
+    System.out.println("Preferences file location: " + Base.getSettingsFile("preferences.txt").getAbsolutePath());
+    System.out.println("Saved last sketch path: " + parentFolder.getAbsolutePath());
 
     try {
       // read the sketch.properties file or get an empty Settings object

--- a/core/methods/src/PAppletMethods.java
+++ b/core/methods/src/PAppletMethods.java
@@ -9,7 +9,8 @@ import java.io.PrintStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant
+        .BuildException;
 import org.apache.tools.ant.Task;
 
 


### PR DESCRIPTION
Feature: Restore Last Sketch on Startup
This pull request implements a usability enhancement for the Processing IDE: automatically reopening the last sketch that was open when the program was last closed.

Description
When the IDE is launched, it checks the preferences file for a saved last.sketch.path. If found and valid, it restores and opens that sketch instead of starting with a blank/new one. This mimics the behavior of many modern IDEs and improves the developer experience.

Key Changes
Added logic to Base.java to read and validate the last sketch path on startup.

Updated handleOpen() to save the current sketch path to preferences upon opening.

Added debug logs to assist with troubleshooting.

Why This Matters
I believe this feature aligns with how most users expect their development tools to behave. By preserving context between sessions, it improves workflow continuity and reduces friction when working on ongoing projects.

Notes
This was developed independently in my fork since the upstream issue has not yet been assigned.
The original issue for this enhancement can be found here: [#1132](https://github.com/processing/processing4/issues/1132)